### PR TITLE
Create node.js.yml CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,42 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+    - 'nextjs/**'
+    - 'websocket-server/**'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+    - 'nextjs/**'
+    - 'websocket-server/**'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js 23
+      uses: actions/setup-node@v4
+      with:
+        node-version: '23.x'
+        cache: 'npm'
+
+    - name: Install dependencies and run tests for nextjs
+      if: contains(github.event.head_commit.message, 'nextjs')
+      working-directory: ./nextjs
+      run: |
+        npm ci
+        npm run build --if-present
+        npm test
+
+    - name: Install dependencies and run tests for websocket-server
+      if: contains(github.event.head_commit.message, 'websocket-server')
+      working-directory: ./websocket-server
+      run: |
+        npm ci
+        npm run build --if-present
+        npm test


### PR DESCRIPTION
## Description:
This PR sets up a CI pipeline using GitHub Actions to test and build our Node.js applications in the `nextjs` and `websocket-server` directories.

## Changes:
- Added a new `.github/workflows/nodejs-ci.yml` file.
- The CI pipeline tests across Node.js version 23.x.
-  Run jobs when files in specific directories (`nextjs` or `websocket-server`) are modified using the `paths` filter.
- For each of the `nextjs` and `websocket-server` directories:
  - Installs dependencies using `npm ci`.
  - Runs build (if present).
  - Runs tests for both.

